### PR TITLE
Setting menu height as auto

### DIFF
--- a/src/components/personal-information/index.module.scss
+++ b/src/components/personal-information/index.module.scss
@@ -82,6 +82,7 @@
 
         > span + div + div {
           overflow: auto;
+          height: auto;
           > div {
             height: auto;
           }


### PR DESCRIPTION
* Set menu height as auto to override previous css selectors 

ref: https://tipit.avaza.com/project/view/304272#!tab=task-pane&task=2954275

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>