### PR TITLE
Change id and name for company field to ignore autocomplete

### DIFF
--- a/src/components/personal-information/index.js
+++ b/src/components/personal-information/index.js
@@ -152,8 +152,8 @@ const PersonalInfoComponent = ({
                                     <div className={styles.fieldWrapper}>
                                         <div>
                                             <RegistrationCompanyInput
-                                                id="company"
-                                                name="company"
+                                                id="reg-comp-input"
+                                                name="reg-comp-input"
                                                 data-testid="company"
                                                 styles={customStyles}
                                                 summitId={summitId}


### PR DESCRIPTION
* The autocomplete option is already off in the input field, but this not prevents the browser to display the autocomplete dropdown with saved data.

![image](https://github.com/fntechgit/summit-registration-lite/assets/19543853/2fee7cd4-d772-464a-894f-6dd797e19290)
![image](https://github.com/fntechgit/summit-registration-lite/assets/19543853/7cbfc827-d5f5-4bce-a021-8cb9936a56d7)

ref: https://tipit.avaza.com/project/view/332800#!tab=task-pane&groupby=ProjectSection&view=vertical&task=3369746&stafilter=NotComplete&fileview=grid

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>
