### PR TITLE
Prevent widget reset on summit data update, improve UX

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -92,8 +92,6 @@ const customErrorHandler = (err, res) => (dispatch, state) => {
 
 export const getTicketTypesAndTaxes = (summitId) => async (dispatch) => {
 
-    dispatch(startWidgetLoading());
-
     return Promise.all([
         dispatch(getTicketTypes(summitId)),
         dispatch(getTaxesTypes(summitId))
@@ -102,8 +100,6 @@ export const getTicketTypesAndTaxes = (summitId) => async (dispatch) => {
     }).catch((err) => {
         console.log(err);
         return Promise.reject(err);
-    }).finally(() => {
-        dispatch(stopWidgetLoading());
     })
 };
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -92,6 +92,8 @@ const customErrorHandler = (err, res) => (dispatch, state) => {
 
 export const getTicketTypesAndTaxes = (summitId) => async (dispatch) => {
 
+    dispatch(startWidgetLoading());
+
     return Promise.all([
         dispatch(getTicketTypes(summitId)),
         dispatch(getTaxesTypes(summitId))
@@ -100,6 +102,8 @@ export const getTicketTypesAndTaxes = (summitId) => async (dispatch) => {
     }).catch((err) => {
         console.log(err);
         return Promise.reject(err);
+    }).finally(() => {
+        dispatch(stopWidgetLoading());
     })
 };
 

--- a/src/components/button-bar/index.js
+++ b/src/components/button-bar/index.js
@@ -15,7 +15,7 @@ import React from 'react';
 
 import styles from "./index.module.scss";
 import { isInPersonTicketType } from "../../actions";
-import { STEP_PAYMENT, STEP_PERSONAL_INFO, STEP_SELECT_TICKET_TYPE } from '../../utils/constants';
+import { STEP_COMPLETE, STEP_PAYMENT, STEP_PERSONAL_INFO, STEP_SELECT_TICKET_TYPE } from '../../utils/constants';
 
 const ButtonBarComponent = ({ step, changeStep, validatePromoCode, onValidateError, formValues, removeReservedTicket, inPersonDisclaimer }) => {
     const { ticketType, ticketQuantity } = formValues || {};
@@ -24,11 +24,11 @@ const ButtonBarComponent = ({ step, changeStep, validatePromoCode, onValidateErr
 
     return (
         <div className={`${styles.outerWrapper}`}>
-            {step !== 3 &&
+            {step !== STEP_COMPLETE &&
                 <>
                     <div className={`${styles.innerWrapper}`}>
                         <div className={styles.required}>
-                            {step !== 0 && <span>* Required fields <br /> </span>}
+                            {step !== STEP_SELECT_TICKET_TYPE && <span>* Required fields <br /> </span>}
                         </div>
                         <div className={styles.actions}>
                             {/* Back Button */}

--- a/src/components/button-bar/index.js
+++ b/src/components/button-bar/index.js
@@ -38,7 +38,7 @@ const ButtonBarComponent = ({ step, changeStep, validatePromoCode, onValidateErr
                             {step === STEP_SELECT_TICKET_TYPE && <button disabled={!ticketType} className={`${styles.button} button`} onClick={() => validatePromoCode({ ...ticketType, ticketQuantity }, onValidateError)}>{nextButtonText}</button>}
                             {step === STEP_PERSONAL_INFO && ticketType?.cost === 0 && <button className={`${styles.button} button`} type="submit" form="personal-info-form">Get Ticket</button>}
                             {step === STEP_PERSONAL_INFO && ticketType?.cost > 0 && <button className={`${styles.button} button`} type="submit" form="personal-info-form">Next</button>}
-                            {step === STEP_PAYMENT && <button className={`${styles.button} button`} type="submit" form="payment-form">Pay Now</button>}
+                            {step === STEP_PAYMENT && <button className={`${styles.button} button`} id="payment-form-btn" type="submit" form="payment-form">Pay Now</button>}
                         </div>
                     </div>
                 </>

--- a/src/components/registration-lite.js
+++ b/src/components/registration-lite.js
@@ -182,7 +182,7 @@ const RegistrationLite = (
     useEffect(() => {
         loadSession({ ...rest, summitData, profileData });
         if (!profileData) {
-            changeStep(0);
+            changeStep(STEP_SELECT_TICKET_TYPE);
         }
     }, [])
 
@@ -194,8 +194,8 @@ const RegistrationLite = (
 
     useEffect(() => {
         // check if there's personal information data and no ticket data to reset widget
-        if (step > 0 && !registrationForm.values?.ticketType && !reservation) {
-            changeStep(0);
+        if (step > STEP_SELECT_TICKET_TYPE && !registrationForm.values?.ticketType && !reservation) {
+            changeStep(STEP_SELECT_TICKET_TYPE);
         }
     }, [registrationForm.values, step]);
 
@@ -217,7 +217,7 @@ const RegistrationLite = (
         // Reset the step when closed to avoid unexpected behavior from `useEffect`s w/in other steps.
         // (i.e., recalling `onPurchaseComplete` after a user completes one order, closes the window, and then reopens the registration widget)
         const closeAndClearState = () => {
-            changeStep(0);
+            changeStep(STEP_SELECT_TICKET_TYPE);
             clearWidgetState();
             if (closeWidget) {
                 closeWidget();
@@ -275,7 +275,7 @@ const RegistrationLite = (
 
                         {profileData && ticketTaxesError && <TicketTaxesError ticketTaxesErrorMessage={ticketTaxesErrorMessage} retryTicketTaxes={() => handleGetTicketTypesAndTaxes(summitData?.id)} />}
 
-                        {profileData && ticketTaxesLoaded && !ticketTaxesError && allowedTicketTypes.length === 0 && step !== 3  && <NoAllowedTickets noAllowedTicketsMessage={noAllowedTicketsMessage} />}
+                        {profileData && ticketTaxesLoaded && !ticketTaxesError && allowedTicketTypes.length === 0 && step !== STEP_COMPLETE  && <NoAllowedTickets noAllowedTicketsMessage={noAllowedTicketsMessage} />}
 
                         {!ticketTaxesError &&
                             <div className={styles.stepsWrapper}>
@@ -307,7 +307,7 @@ const RegistrationLite = (
                                     />
                                 )}
 
-                                {profileData && step !== 3 && (
+                                {profileData && step !== STEP_COMPLETE && (
                                     <>
                                         { ownedTickets.length > 0 &&
                                             <TicketOwnedComponent ownedTickets={ownedTickets} />}
@@ -410,7 +410,7 @@ const RegistrationLite = (
                             </div>
                         }
 
-                        {ticketTaxesLoaded && !ticketTaxesError && profileData && step !== 3 && allowedTicketTypes.length > 0 && (
+                        {ticketTaxesLoaded && !ticketTaxesError && profileData && step !== STEP_COMPLETE && allowedTicketTypes.length > 0 && (
                             <ButtonBarComponent
                                 step={step}
                                 inPersonDisclaimer={inPersonDisclaimer}

--- a/src/components/registration-lite.js
+++ b/src/components/registration-lite.js
@@ -194,7 +194,7 @@ const RegistrationLite = (
 
     useEffect(() => {
         // check if there's personal information data and no ticket data to reset widget
-        if (step > 0 && !registrationForm.values?.ticketType) {
+        if (step > 0 && !registrationForm.values?.ticketType && !reservation) {
             changeStep(0);
         }
     }, [registrationForm.values, step]);
@@ -234,7 +234,8 @@ const RegistrationLite = (
     };
 
     const handleGetTicketTypesAndTaxes = (summitId) => {
-        setTicketTaxesError(false);        
+        setTicketTaxesError(false);
+        setTicketTaxesLoaded(false);
         getTicketTypesAndTaxes(summitId)
             .then()
             .catch((error) => {
@@ -306,7 +307,7 @@ const RegistrationLite = (
                                     />
                                 )}
 
-                                {profileData && step !== 3 && allowedTicketTypes.length > 0 && (
+                                {profileData && step !== 3 && (
                                     <>
                                         { ownedTickets.length > 0 &&
                                             <TicketOwnedComponent ownedTickets={ownedTickets} />}

--- a/src/components/registration-lite.js
+++ b/src/components/registration-lite.js
@@ -410,7 +410,7 @@ const RegistrationLite = (
                             </div>
                         }
 
-                        {ticketTaxesLoaded && !ticketTaxesError && profileData && step !== STEP_COMPLETE && allowedTicketTypes.length > 0 && (
+                        {!ticketTaxesError && profileData && step !== STEP_COMPLETE && (
                             <ButtonBarComponent
                                 step={step}
                                 inPersonDisclaimer={inPersonDisclaimer}

--- a/src/components/stripe-form/index.js
+++ b/src/components/stripe-form/index.js
@@ -105,7 +105,8 @@ const StripeForm = ({ reservation, payTicket, userProfile, stripeOptions, provid
         },
     }, stripeOptions?.style);
 
-    const onSubmit = async (data) => {
+    const onSubmit = async (data, ev) => {
+
         setStripeErrors({});
 
         if (!stripe) {
@@ -113,7 +114,8 @@ const StripeForm = ({ reservation, payTicket, userProfile, stripeOptions, provid
             // form submission until Stripe.js has loaded.
             return;
         }
-
+        const btn = document.getElementById('payment-form-btn');
+        if(btn) btn.disabled = true;
         const cardElement = elements.getElement(CardNumberElement);
         // @see https://stripe.com/docs/js/tokens_sources/create_token?type=cardElement
         const { error, token } = await stripe.createToken(cardElement, {
@@ -130,14 +132,17 @@ const StripeForm = ({ reservation, payTicket, userProfile, stripeOptions, provid
         if (token) {
             cardElement.update({disabled: true})
             payTicket(provider, { token, stripe, zipCode : data.zipCode });
-        } else if (error) {
+            return;
+        }
+        if (error) {
+            if(btn) btn.disabled = false;
             if (stripeErrorCodeMap[error.code]) {
                 setStripeErrors({
                     [stripeErrorCodeMap[error.code].field]: stripeErrorCodeMap[error.code].message || error.message
                 });
-            } else {
-                Swal.fire("Payment error", error.message, "warning");
+                return;
             }
+            Swal.fire("Payment error", error.message, "warning");
         }
     };
 

--- a/src/components/ticket-type/index.js
+++ b/src/components/ticket-type/index.js
@@ -58,7 +58,8 @@ const TicketTypeComponent = ({
 
     useEffect(() => {
         if (reservation && reservation.tickets?.length > 0) {
-            setTicket(allowedTicketTypes.find(t => t.id === reservation.tickets[0].ticket_type_id))
+            setTicket(allowedTicketTypes.find(t => t.id === reservation.tickets[0].ticket_type_id));
+            setQuantity(reservation.tickets.length);
         }
     }, [])
 

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -39,6 +39,7 @@ import {
 
 import { LOGOUT_USER } from 'openstack-uicore-foundation/lib/security/actions';
 import moment from 'moment';
+import { STEP_SELECT_TICKET_TYPE } from './utils/constants';
 
 const localNowUtc = moment().unix();
 
@@ -46,7 +47,7 @@ const localNowUtc = moment().unix();
 const DEFAULT_STATE = {
     reservation: null,
     checkout: null,
-    step: 0,
+    step: STEP_SELECT_TICKET_TYPE,
     widgetLoading: false,
     passwordless: {
         email: null,

--- a/src/utils/payment-providers/lawpay-provider.js
+++ b/src/utils/payment-providers/lawpay-provider.js
@@ -10,6 +10,7 @@ import {
 } from "../../actions";
 
 import Swal from "sweetalert2";
+import { STEP_COMPLETE, STEP_PERSONAL_INFO } from "../constants";
 
 export class LawPayProvider {
 
@@ -83,12 +84,12 @@ export class LawPayProvider {
             .then((payload) => {
                 this.dispatch(stopWidgetLoading());
                 this.dispatch(createAction(CLEAR_RESERVATION)({}));
-                this.dispatch(changeStep(3));
+                this.dispatch(changeStep(STEP_COMPLETE));
                 return (payload);
             })
             .catch(e => {
                 this.dispatch(removeReservedTicket());
-                this.dispatch(changeStep(1));
+                this.dispatch(changeStep(STEP_PERSONAL_INFO));
                 this.dispatch(stopWidgetLoading());
                 return (e);
             });


### PR DESCRIPTION
* Check present reservation on summit data update to avoid widget reset

ref: https://tipit.avaza.com/project/view#!tab=task-pane&task=3526936

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>
