### PR TITLE
fix: disable 'pay now' button until stripe form is loaded

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -54,6 +54,8 @@ export const SET_CURRENT_PROMO_CODE = 'SET_CURRENT_PROMO_CODE';
 export const CLEAR_CURRENT_PROMO_CODE = 'CLEAR_CURRENT_PROMO_CODE';
 export const VALIDATE_PROMO_CODE = 'VALIDATE_PROMO_CODE';
 
+export const STRIPE_READY = 'STRIPE_READY';
+
 export const startWidgetLoading = createAction(START_WIDGET_LOADING);
 export const stopWidgetLoading = createAction(STOP_WIDGET_LOADING);
 
@@ -511,4 +513,8 @@ export const getMyInvitation = (summitId) => async (dispatch, getState, { apiBas
 
 export const updateClock = (timestamp) => (dispatch) => {
     dispatch(createAction(UPDATE_CLOCK)({ timestamp }));
+};
+
+export const setStripeReady = () => (dispatch) => {
+    dispatch(createAction(STRIPE_READY)({}));
 };

--- a/src/components/button-bar/index.js
+++ b/src/components/button-bar/index.js
@@ -38,7 +38,7 @@ const ButtonBarComponent = ({ step, changeStep, validatePromoCode, onValidateErr
                             {step === STEP_SELECT_TICKET_TYPE && <button disabled={!ticketType} className={`${styles.button} button`} onClick={() => validatePromoCode({ ...ticketType, ticketQuantity, promoCode }, onValidateError)}>{nextButtonText}</button>}
                             {step === STEP_PERSONAL_INFO && ticketType?.cost === 0 && <button className={`${styles.button} button`} type="submit" form="personal-info-form">Get Ticket</button>}
                             {step === STEP_PERSONAL_INFO && ticketType?.cost > 0 && <button className={`${styles.button} button`} type="submit" form="personal-info-form">Next</button>}
-                            {step === STEP_PAYMENT && <button className={`${styles.button} button`} id="payment-form-btn" type="submit" form="payment-form">Pay Now</button>}
+                            {step === STEP_PAYMENT && <button className={`${styles.button} button`} id="payment-form-btn" type="submit" disabled form="payment-form">Loading</button>}
                         </div>
                     </div>
                 </>

--- a/src/components/button-bar/index.js
+++ b/src/components/button-bar/index.js
@@ -12,7 +12,7 @@
  **/
 
 import React from 'react';
-
+import T from 'i18n-react';
 import styles from "./index.module.scss";
 import { isInPersonTicketType } from "../../actions";
 import { STEP_COMPLETE, STEP_PAYMENT, STEP_PERSONAL_INFO, STEP_SELECT_TICKET_TYPE } from '../../utils/constants';
@@ -32,13 +32,13 @@ const ButtonBarComponent = ({ step, changeStep, validatePromoCode, onValidateErr
                         </div>
                         <div className={styles.actions}>
                             {/* Back Button */}
-                            {step !== STEP_SELECT_TICKET_TYPE && step !== STEP_PAYMENT && <button className={`${styles.button} button`} onClick={() => changeStep(step - 1)}>&lt; Back</button>}
-                            {step !== STEP_SELECT_TICKET_TYPE && step === STEP_PAYMENT && <button className={`${styles.button} button`} onClick={() => removeReservedTicket()}>&lt; Back</button>}
+                            {step !== STEP_SELECT_TICKET_TYPE && step !== STEP_PAYMENT && <button className={`${styles.button} button`} onClick={() => changeStep(step - 1)}>&lt; {T.translate("bar_button.back")}</button>}
+                            {step !== STEP_SELECT_TICKET_TYPE && step === STEP_PAYMENT && <button className={`${styles.button} button`} onClick={() => removeReservedTicket()}>&lt; {T.translate("bar_button.back")}</button>}
                             {/* Next Button */}
                             {step === STEP_SELECT_TICKET_TYPE && <button disabled={!ticketType} className={`${styles.button} button`} onClick={() => validatePromoCode({ ...ticketType, ticketQuantity, promoCode }, onValidateError)}>{nextButtonText}</button>}
-                            {step === STEP_PERSONAL_INFO && ticketType?.cost === 0 && <button className={`${styles.button} button`} type="submit" form="personal-info-form">Get Ticket</button>}
-                            {step === STEP_PERSONAL_INFO && ticketType?.cost > 0 && <button className={`${styles.button} button`} type="submit" form="personal-info-form">Next</button>}
-                            {step === STEP_PAYMENT && <button className={`${styles.button} button`} id="payment-form-btn" type="submit" disabled form="payment-form">Loading</button>}
+                            {step === STEP_PERSONAL_INFO && ticketType?.cost === 0 && <button className={`${styles.button} button`} type="submit" form="personal-info-form">{T.translate("bar_button.get_ticket")}</button>}
+                            {step === STEP_PERSONAL_INFO && ticketType?.cost > 0 && <button className={`${styles.button} button`} type="submit" form="personal-info-form">{T.translate("bar_button.next")}</button>}
+                            {step === STEP_PAYMENT && <button className={`${styles.button} button`} id="payment-form-btn" type="submit" disabled form="payment-form">{T.translate("bar_button.loading")}</button>}
                         </div>
                     </div>
                 </>

--- a/src/components/button-bar/index.js
+++ b/src/components/button-bar/index.js
@@ -17,7 +17,7 @@ import styles from "./index.module.scss";
 import { isInPersonTicketType } from "../../actions";
 import { STEP_COMPLETE, STEP_PAYMENT, STEP_PERSONAL_INFO, STEP_SELECT_TICKET_TYPE } from '../../utils/constants';
 
-const ButtonBarComponent = ({ step, changeStep, validatePromoCode, onValidateError, formValues, removeReservedTicket, inPersonDisclaimer }) => {
+const ButtonBarComponent = ({ step, changeStep, validatePromoCode, onValidateError, formValues, removeReservedTicket, inPersonDisclaimer, stripeReady }) => {
     const { ticketType, ticketQuantity, promoCode } = formValues || {};
 
     const nextButtonText = inPersonDisclaimer && ticketType && isInPersonTicketType(ticketType) ? 'Accept' : 'Next';
@@ -38,7 +38,13 @@ const ButtonBarComponent = ({ step, changeStep, validatePromoCode, onValidateErr
                             {step === STEP_SELECT_TICKET_TYPE && <button disabled={!ticketType} className={`${styles.button} button`} onClick={() => validatePromoCode({ ...ticketType, ticketQuantity, promoCode }, onValidateError)}>{nextButtonText}</button>}
                             {step === STEP_PERSONAL_INFO && ticketType?.cost === 0 && <button className={`${styles.button} button`} type="submit" form="personal-info-form">{T.translate("bar_button.get_ticket")}</button>}
                             {step === STEP_PERSONAL_INFO && ticketType?.cost > 0 && <button className={`${styles.button} button`} type="submit" form="personal-info-form">{T.translate("bar_button.next")}</button>}
-                            {step === STEP_PAYMENT && <button className={`${styles.button} button`} id="payment-form-btn" type="submit" disabled form="payment-form">{T.translate("bar_button.loading")}</button>}
+                            {step === STEP_PAYMENT && <button className={`${styles.button} button`} id="payment-form-btn" type="submit" disabled={!stripeReady} form="payment-form">
+                                {stripeReady ?
+                                    T.translate("bar_button.pay_now")
+                                    :
+                                    T.translate("bar_button.loading")
+                                }
+                            </button>}
                         </div>
                     </div>
                 </>

--- a/src/components/button-bar/index.module.scss
+++ b/src/components/button-bar/index.module.scss
@@ -22,6 +22,9 @@
           display: flex;          
           button {
               margin-left: 10px;
+              &:disabled {
+                cursor: not-allowed !important;
+              }
           }
       }
   }

--- a/src/components/payment/index.js
+++ b/src/components/payment/index.js
@@ -21,7 +21,7 @@ import { Helmet } from 'react-helmet';
 import { PAYMENT_PROVIDER_LAWPAY, PAYMENT_PROVIDER_STRIPE } from '../../utils/constants';
 
 
-const PaymentComponent = ({ isActive, userProfile, reservation, payTicket, providerKey, provider, providerOptions, successfulPaymentReturnUrl, timestamp, hidePostalCode, onError }) => {
+const PaymentComponent = ({ isActive, userProfile, reservation, payTicket, providerKey, provider, providerOptions, successfulPaymentReturnUrl, timestamp, hidePostalCode, onError, onStripeReady }) => {
 
     const [ref, { height }] = useMeasure();
 
@@ -55,6 +55,7 @@ const PaymentComponent = ({ isActive, userProfile, reservation, payTicket, provi
                                     stripeReturnUrl={successfulPaymentReturnUrl}
                                     hidePostalCode={hidePostalCode}
                                     onError={onError}
+                                    onStripeReady={onStripeReady}
                                 />
                             }
                             {provider === PAYMENT_PROVIDER_LAWPAY &&

--- a/src/components/registration-lite.js
+++ b/src/components/registration-lite.js
@@ -38,7 +38,8 @@ import {
     loadProfileData,
     removePromoCode,
     applyPromoCode,
-    validatePromoCode
+    validatePromoCode,
+    setStripeReady
 } from '../actions';
 
 import AjaxLoader from "openstack-uicore-foundation/lib/components/ajaxloader";
@@ -161,6 +162,8 @@ const RegistrationLite = (
         removePromoCode,
         applyPromoCode,
         validatePromoCode,
+        setStripeReady,
+        stripeReady,
         ...rest
     }) => {
 
@@ -443,6 +446,7 @@ const RegistrationLite = (
                                                     providerOptions={providerOptions}
                                                     hidePostalCode={hidePostalCode}
                                                     onError={onError}
+                                                    onStripeReady={setStripeReady}
                                                     successfulPaymentReturnUrl={successfulPaymentReturnUrl}
                                                 />
                                             </div>
@@ -488,6 +492,7 @@ const RegistrationLite = (
                                     onError: (err, res) => setFormErrors(res.body.errors)
                                 }}
                                 changeStep={changeStep}
+                                stripeReady={stripeReady}
                             />
                         )}
                     </div>
@@ -514,6 +519,7 @@ const mapStateToProps = ({ registrationLiteState }) => ({
     passwordlessCodeError: registrationLiteState.passwordless.error,
     nowUtc: registrationLiteState.nowUtc,
     promoCode: registrationLiteState.promoCode,
+    stripeReady: registrationLiteState.stripeReady
 })
 
 RegistrationLite.defaultProps = {
@@ -577,5 +583,6 @@ export default connect(mapStateToProps, {
     loadProfileData,
     applyPromoCode,
     removePromoCode,
-    validatePromoCode
+    validatePromoCode,
+    setStripeReady
 })(RegistrationLite)

--- a/src/components/stripe-component/index.js
+++ b/src/components/stripe-component/index.js
@@ -21,7 +21,7 @@ import { isFreeOrder, isPrePaidOrder } from '../../utils/utils';
 import { DefaultBGColor, DefaultTextColor, DefaultHintColor } from '../../utils/constants';
 
 
-const StripeProvider = ({ userProfile, reservation, payTicket, providerKey, provider, stripeOptions, stripeReturnUrl, hidePostalCode, onError }) => {
+const StripeProvider = ({ userProfile, reservation, payTicket, providerKey, provider, stripeOptions, stripeReturnUrl, hidePostalCode, onError, onStripeReady }) => {
 
     const stripePromise = useMemo(() => loadStripe(providerKey), [providerKey]);
 
@@ -114,6 +114,7 @@ const StripeProvider = ({ userProfile, reservation, payTicket, providerKey, prov
                 hidePostalCode={hidePostalCode}
                 stripeReturnUrl={stripeReturnUrl}
                 onError={onError}
+                onStripeReady={onStripeReady}
             />
         </Elements>
         :

--- a/src/components/stripe-form/index.js
+++ b/src/components/stripe-form/index.js
@@ -12,6 +12,7 @@
  **/
 
 import React, { useEffect, useState } from 'react';
+import T from 'i18n-react';
 import { useForm } from 'react-hook-form';
 
 import {
@@ -78,7 +79,7 @@ const StripeForm = ({ reservation, payTicket, userProfile, provider, hidePostalC
                     const btn = document.getElementById("payment-form-btn");
                     if (btn) {
                         btn.disabled = false;
-                        btn.textContent = "Pay Now";
+                        btn.textContent = T.translate("bar_button.pay_now");
                     }
                 });
             }

--- a/src/components/stripe-form/index.js
+++ b/src/components/stripe-form/index.js
@@ -70,7 +70,18 @@ const StripeForm = ({ reservation, payTicket, userProfile, provider, hidePostalC
 
     useEffect(() => {
         if (elements) {
-            setPaymentElement(elements.getElement('payment'));
+            const pe = elements.getElement("payment");
+            setPaymentElement(pe);
+
+            if (pe) {
+                pe.on("ready", () => {
+                    const btn = document.getElementById("payment-form-btn");
+                    if (btn) {
+                        btn.disabled = false;
+                        btn.textContent = "Pay Now";
+                    }
+                });
+            }
         }
     }, [elements]);
 

--- a/src/components/stripe-form/index.js
+++ b/src/components/stripe-form/index.js
@@ -64,7 +64,7 @@ const stripeErrorCodeMap = {
 };
 
 
-const StripeForm = ({ reservation, payTicket, userProfile, provider, hidePostalCode, stripeReturnUrl, onError }) => {
+const StripeForm = ({ reservation, payTicket, userProfile, provider, hidePostalCode, stripeReturnUrl, onError, onStripeReady }) => {
     const stripe = useStripe();
     const elements = useElements();
     const [paymentElement, setPaymentElement] = useState(null);
@@ -75,13 +75,7 @@ const StripeForm = ({ reservation, payTicket, userProfile, provider, hidePostalC
             setPaymentElement(pe);
 
             if (pe) {
-                pe.on("ready", () => {
-                    const btn = document.getElementById("payment-form-btn");
-                    if (btn) {
-                        btn.disabled = false;
-                        btn.textContent = T.translate("bar_button.pay_now");
-                    }
-                });
+                pe.on("ready", () => onStripeReady());
             }
         }
     }, [elements]);

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -15,5 +15,12 @@
   },
   "promo_code": {
     "promo_code_tooltip": "Only one promo code can be used per order; the code will be applied to all tickets in this order. If you'd like to use multiple promo codes, please place a separate registration order for each promo code."
+  },
+  "bar_button": {
+    "back": "Back",
+    "next": "Next",
+    "get_ticket": "Get Ticket",
+    "pay_now": "Pay Now",
+    "loading": "Loading"
   }
 }

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -35,6 +35,7 @@ import {
     LOAD_PROFILE_DATA,
     SET_CURRENT_PROMO_CODE,
     CLEAR_CURRENT_PROMO_CODE,
+    STRIPE_READY,
 } from './actions';
 
 import { LOGOUT_USER } from 'openstack-uicore-foundation/lib/security/actions';
@@ -68,7 +69,8 @@ const DEFAULT_STATE = {
         userProfile: null,
     },
     nowUtc: localNowUtc,
-    promoCode: ''
+    promoCode: '',
+    stripeReady: false
 };
 
 const RegistrationLiteReducer = (state = DEFAULT_STATE, action) => {
@@ -117,7 +119,7 @@ const RegistrationLiteReducer = (state = DEFAULT_STATE, action) => {
             };
         }
         case CHANGE_STEP: {
-            return { ...state, step: payload }
+            return { ...state, step: payload, stripeReady: false }
         }
         case GET_TICKET_TYPES: {
             return { ...state, ticketTypes: payload.response.data, requestedTicketTypes: true };
@@ -167,6 +169,9 @@ const RegistrationLiteReducer = (state = DEFAULT_STATE, action) => {
         case SET_CURRENT_PROMO_CODE:{
             const { currentPromoCode } = payload;
             return { ...state, promoCode: currentPromoCode}
+        }
+        case STRIPE_READY: {
+            return { ...state, stripeReady: true }
         }
         default: {
             return state;


### PR DESCRIPTION
ref: https://app.clickup.com/t/86b73bfnu

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added internationalized labels for all action buttons (Back, Get Ticket, Next, Pay, Loading).
  * Payment flow now reports readiness so the pay action shows appropriate label/state and is disabled until ready.

* **Style**
  * Improved disabled button styling with explicit not-allowed cursor for clearer feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->