### PR TITLE
fix: guard against null company in personal-information

### DIFF
--- a/src/components/personal-information/__tests__/personal-information.test.js
+++ b/src/components/personal-information/__tests__/personal-information.test.js
@@ -148,6 +148,50 @@ it('PersonalInfoComponent checks that company input field is hidden when `showCo
     });
 });
 
+it('does not crash when company is null on submit', async () => {
+    const { getByTestId } = render(
+        <PersonalInfoComponent
+            isActive={true}
+            formValues={mockFormValues}
+            userProfile={mockProfile}
+            handleCompanyError={mockCallBack}
+            changeForm={mockSubmit}
+            summitId={13}
+        />
+    );
+
+    // Simulate CompanyInputV2 clearing company to null
+    const companyInput = getByTestId('company');
+    fireEvent.change(companyInput, { target: { value: null } });
+
+    const form = getByTestId('personal-form');
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+        const companyError = getByTestId('company-error');
+        expect(companyError).toBeTruthy();
+    });
+
+    expect(mockSubmit).not.toHaveBeenCalled();
+});
+
+it('does not crash when company is null in summary display', () => {
+    const { getByTestId } = render(
+        <PersonalInfoComponent
+            isActive={false}
+            formValues={mockFormValues}
+            userProfile={mockProfile}
+            handleCompanyError={mockCallBack}
+        />
+    );
+
+    const personalInfo = getByTestId('personal-info');
+    expect(personalInfo).toBeTruthy();
+    expect(personalInfo.firstElementChild.innerHTML).toBe(
+        `${mockProfile.given_name} ${mockProfile.family_name}`
+    );
+});
+
 // it('PersonalInfoComponent set the fields if there is a reservation', async () => {
 
 //     const { getByTestId } = render(<PersonalInfoComponent isActive={true} userProfile={mockProfile} reservation={mockReservation} />);

--- a/src/components/personal-information/__tests__/personal-information.test.js
+++ b/src/components/personal-information/__tests__/personal-information.test.js
@@ -192,6 +192,37 @@ it('does not crash when company is null in summary display', () => {
     );
 });
 
+it('shows company validation error when reservation has no owner_company', async () => {
+    const reservationNoCompany = {
+        owner_first_name: 'Reservation Name',
+        owner_last_name: 'Reservation Last Name',
+        owner_email: 'reservation@email.com',
+        owner_company: '',
+    };
+
+    const { getByTestId } = render(
+        <PersonalInfoComponent
+            isActive={true}
+            formValues={mockFormValues}
+            userProfile={mockProfile}
+            handleCompanyError={mockCallBack}
+            changeForm={mockSubmit}
+            reservation={reservationNoCompany}
+            summitId={13}
+        />
+    );
+
+    const form = getByTestId('personal-form');
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+        const companyError = getByTestId('company-error');
+        expect(companyError).toBeTruthy();
+    });
+
+    expect(mockSubmit).not.toHaveBeenCalled();
+});
+
 // it('PersonalInfoComponent set the fields if there is a reservation', async () => {
 
 //     const { getByTestId } = render(<PersonalInfoComponent isActive={true} userProfile={mockProfile} reservation={mockReservation} />);

--- a/src/components/personal-information/__tests__/personal-information.test.js
+++ b/src/components/personal-information/__tests__/personal-information.test.js
@@ -2,6 +2,26 @@ import React from 'react';
 import { cleanup, fireEvent, render as render, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
+// Mock uicore components to avoid @react-pdf dependency resolution failure
+jest.mock('openstack-uicore-foundation/lib/components', () => ({
+    RadioList: ({ options, id }) => (
+        <div data-testid={`radio-list-${id}`}>
+            {options.map((op) => (
+                <div key={op.value}>
+                    <input type="radio" id={`radio_${id}_${op.value}`} value={op.value} readOnly />
+                    <label htmlFor={`radio_${id}_${op.value}`}>{op.label}</label>
+                </div>
+            ))}
+        </div>
+    ),
+}));
+
+jest.mock('openstack-uicore-foundation/lib/components/inputs/company-input-v2', () => {
+    return function MockCompanyInput({ value, onChange, placeholder, ...props }) {
+        return <input data-testid="company" name="company" onChange={onChange} value={value?.name || ''} placeholder={placeholder || 'Select a company'} />;
+    };
+});
+
 import PersonalInfoComponent from "..";
 
 const mockReservation = {
@@ -49,8 +69,8 @@ it('PersonalInfoComponent set the initial values from the user profile', async (
     expect(lastName.value).toBe(mockProfile.family_name);
     expect(email.value).toBe(mockProfile.email);
 
-    const placeholder = getByText('Select a company');
-    expect(placeholder).toBeTruthy();
+    const company = getByTestId('company');
+    expect(company).toBeTruthy();
 });
 
 it('PersonalInfoComponent shows the personal data when is not active', async () => {

--- a/src/components/personal-information/index.js
+++ b/src/components/personal-information/index.js
@@ -94,7 +94,7 @@ const PersonalInfoComponent = ({
         firstName: reservation.owner_first_name ? reservation.owner_first_name : personalInfo.firstName,
         lastName: reservation.owner_last_name ? reservation.owner_last_name : personalInfo.lastName,
         email: reservation.owner_email ? reservation.owner_email : personalInfo.email,
-        company: { id: null, name: reservation.owner_company ? reservation.owner_company : personalInfo.company },
+        company: { id: null, name: reservation.owner_company || personalInfo.company?.name || '' },
       });
     }
   }, []);

--- a/src/components/personal-information/index.js
+++ b/src/components/personal-information/index.js
@@ -107,7 +107,7 @@ const PersonalInfoComponent = ({
   };
 
   const onSubmit = (data) => {
-    if (!personalInfo.company.name && showCompanyInput) {
+    if (!personalInfo.company?.name && showCompanyInput) {
       setCompanyError(true);
       return;
     }
@@ -204,7 +204,7 @@ const PersonalInfoComponent = ({
             {!isActive &&
               <div data-testid="personal-info">
                 <span>
-                  {`${personalInfo.firstName} ${personalInfo.lastName}${personalInfo.company.name ? ` - ${personalInfo.company.name}` : ''}`}
+                  {`${personalInfo.firstName} ${personalInfo.lastName}${personalInfo.company?.name ? ` - ${personalInfo.company.name}` : ''}`}
                 </span>
                 <br />
                 <span>


### PR DESCRIPTION
## Summary
- Guard against null `personalInfo.company` in personal-information component
- `CompanyInputV2` onChange can set company to null when the field is cleared, causing TypeError crash on submit and summary display
- Fix pre-existing test suite import failure (missing uicore mocks)
- Add tests for null company scenarios

ref: https://app.clickup.com/t/86b9p9fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when company information is null or missing in the personal information form. Purchaser header and submit behavior now handle absent company data gracefully.

* **Tests**
  * Expanded test coverage for edge cases where company data is null or reservation lacks an owner company. Tests verify error feedback appears and submission is blocked when appropriate, and that summary/inactive views render safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->