### PR TITLE
fix(ticket-notice): keep warning icon inline with text

### DIFF
--- a/src/components/ticket-notice/index.js
+++ b/src/components/ticket-notice/index.js
@@ -12,7 +12,9 @@ const TicketNotice = ({ message, variant = 'info' }) => {
     return (
         <div className={`${styles.notice} ${styles[variant]}`}>
             {variant === 'error' && <span className={styles.icon}>⚠</span>}
-            {items.map((m, i) => <div key={i}>{m}</div>)}
+            <div className={styles.content}>
+                {items.map((m, i) => <div key={i}>{m}</div>)}
+            </div>
         </div>
     );
 };

--- a/src/components/ticket-notice/index.module.scss
+++ b/src/components/ticket-notice/index.module.scss
@@ -1,8 +1,15 @@
 .notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
   margin-top: 10px;
   padding: 10px 12px;
   border-radius: 4px;
   font-size: 13px;
+}
+
+.content {
+  flex: 1;
 
   > div + div {
     margin-top: 1px;
@@ -22,5 +29,6 @@
 }
 
 .icon {
-  margin-right: 6px;
+  flex-shrink: 0;
+  line-height: 1.4;
 }


### PR DESCRIPTION
## Summary

- TicketNotice rendered the icon as a span followed by block-level `<div>` children, breaking the icon onto its own line above the message.
- Wraps the items in a flex content container so the icon sits inline at the top-left of the notice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced ticket notice layout with improved spacing and alignment for better message presentation and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->