### PR TITLE
fix(promo): SDS-aligned polish for promo-code discovery flow

### DIFF
--- a/e2e/promo-code-date-filter.spec.js
+++ b/e2e/promo-code-date-filter.spec.js
@@ -1,0 +1,103 @@
+const { test, expect } = require('@playwright/test');
+const {
+    ticketType,
+    discoveredCode,
+    discoveryResponse,
+    ticketTypesResponse,
+    taxTypesResponse,
+    validationResponse,
+} = require('./fixtures');
+
+// Post-apply auto-select must scan the date-filtered ticket list (`allowedTicketTypes`),
+// not the raw Redux list (`originalTicketTypes`). Otherwise the widget could pick a ticket
+// that's outside its sales window — the dropdown can't display it and the user is stuck.
+
+const setupRoutes = async (page, { discovery, tickets, validation }) => {
+    await page.route('**/promo-codes/all/discover*', route =>
+        route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(discoveryResponse(discovery)) })
+    );
+    await page.route('**/ticket-types/allowed*', route =>
+        route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(ticketTypesResponse(tickets)) })
+    );
+    await page.route('**/tax-types*', route =>
+        route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(taxTypesResponse()) })
+    );
+    if (validation) {
+        await page.route('**/promo-codes/*/apply*', route =>
+            route.fulfill({ status: validation.status, contentType: 'application/json', body: JSON.stringify(validation.body) })
+        );
+    }
+};
+
+test.describe('post-apply auto-select respects sales window', () => {
+    test('picks the in-window ticket when a discovered code matches both an expired and an active ticket', async ({ page }) => {
+        // Code matches both tickets, but Expired Ticket has a sales_end_date in the past.
+        // Pre-fix, the auto-select scanned originalTicketTypes (unfiltered) and would land
+        // on Expired Ticket — first match in iteration order. Post-fix, only Active Ticket
+        // can be auto-selected because Expired Ticket is excluded by the date filter.
+        const expiredTicket = ticketType({
+            id: 188,
+            name: 'Expired Ticket',
+            sales_start_date: 1000000,    // long ago
+            sales_end_date: 2000000,      // also long ago
+        });
+        const activeTicket = ticketType({
+            id: 200,
+            name: 'Active Ticket',
+            sales_start_date: null,
+            sales_end_date: null,
+        });
+        const code = discoveredCode({
+            auto_apply: true,
+            allowed_ticket_types: [188, 200],
+        });
+
+        await setupRoutes(page, {
+            tickets: [expiredTicket, activeTicket],
+            discovery: [code],
+            validation: { status: 200, body: validationResponse() },
+        });
+        await page.goto('/');
+
+        // Auto-apply runs on load; the post-apply effect picks a qualifying ticket.
+        // The dropdown's selected-ticket slot shows the chosen ticket's name.
+        await expect(page.locator('[data-testid="selected-ticket"]')).toContainText('Active Ticket');
+        await expect(page.locator('[data-testid="selected-ticket"]')).not.toContainText('Expired Ticket');
+    });
+
+    test('never picks an expired ticket even when it is the only qualifying one', async ({ page }) => {
+        // Code matches only the expired ticket. Two active tickets exist (so the
+        // "fall back to the single allowed option" clause cannot mask the bug).
+        // Pre-fix, the widget scanned originalTicketTypes and would land on
+        // Expired Ticket — the only qualifying one. Post-fix, the qualifying
+        // scan is bounded by allowedTicketTypes, so Expired Ticket is never
+        // selectable.
+        const expiredTicket = ticketType({
+            id: 188,
+            name: 'Expired Ticket',
+            sales_start_date: 1000000,
+            sales_end_date: 2000000,
+        });
+        const activeA = ticketType({ id: 200, name: 'Active A', sales_start_date: null, sales_end_date: null });
+        const activeB = ticketType({ id: 201, name: 'Active B', sales_start_date: null, sales_end_date: null });
+        const code = discoveredCode({
+            auto_apply: true,
+            allowed_ticket_types: [188], // only the expired one qualifies
+        });
+
+        await setupRoutes(page, {
+            tickets: [expiredTicket, activeA, activeB],
+            discovery: [code],
+            validation: { status: 200, body: validationResponse() },
+        });
+        await page.goto('/');
+
+        // Give the auto-apply + post-apply effects time to settle.
+        await page.waitForTimeout(500);
+        // Post-fix: no auto-selection happens because the only qualifying ticket
+        // is filtered out by date and the fallback ("if there's a single allowed
+        // option, pick it") cannot fire when more than one is allowed. The dropdown
+        // shows its placeholder. Pre-fix, this slot would have shown "Expired Ticket".
+        await expect(page.locator('[data-testid="no-ticket"]')).toBeVisible();
+    });
+});

--- a/e2e/promo-code-discovery.spec.js
+++ b/e2e/promo-code-discovery.spec.js
@@ -154,15 +154,29 @@ test.describe('auto-apply flow (auto_apply: true)', () => {
         await expect(page.locator('text=You qualify for the following promo code:')).toBeVisible();
     });
 
-    test('does not auto-apply for non-qualifying ticket', async ({ page }) => {
+    test('auto-applies on load and surfaces INVALID when the only ticket is non-qualifying', async ({ page }) => {
         const nonQualifyingTicket = ticketType({ id: 999, name: 'Standard Ticket' });
         await setupRoutes(page, {
             tickets: [nonQualifyingTicket],
             discovery: [autoCode],
+            // Per the SDS, early auto-apply fires whenever a single auto_apply code
+            // exists — independent of which tickets are present. Re-validation against
+            // the lone non-qualifying ticket then catches the mismatch and the user
+            // sees the backend's rejection message.
+            validation: (route) => {
+                if (route.request().url().includes('ticket_type_id%3D%3D999')) {
+                    return route.fulfill({
+                        status: 412,
+                        contentType: 'application/json',
+                        body: JSON.stringify(validationError('Promo code AUTO100 can not be applied to Ticket Type Standard Ticket.')),
+                    });
+                }
+                return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(validationResponse()) });
+            },
         });
         await page.goto('/');
-        await selectTicket(page, 'Standard Ticket');
-        await expect(page.locator('text=Do you have a promo code?')).toBeVisible();
+        await expect(page.locator('input[placeholder="Enter your promo code"]')).toHaveValue('AUTO100');
+        await expect(page.locator('text=Promo code AUTO100 can not be applied to Ticket Type Standard Ticket.')).toBeVisible();
     });
 });
 

--- a/e2e/promo-code-discovery.spec.js
+++ b/e2e/promo-code-discovery.spec.js
@@ -124,6 +124,27 @@ test.describe('suggestion flow (auto_apply: false)', () => {
         await page.fill('input[placeholder="Enter your promo code"]', 'SUGGEST50');
         await expect(page.locator('text=You qualify for the following promo code:')).toBeVisible();
     });
+
+    test('banner swaps to "applies to a different ticket" copy after switching to a non-qualifying ticket', async ({ page }) => {
+        const qualifying = ticketType({ id: 188, name: 'Early Bird Ticket' });
+        const nonQualifying = ticketType({ id: 999, name: 'Standard Ticket' });
+        const code = discoveredCode({ auto_apply: false, code: 'SUGGEST50', allowed_ticket_types: [188] });
+
+        await setupRoutes(page, {
+            tickets: [qualifying, nonQualifying],
+            discovery: [code],
+        });
+        await page.goto('/');
+
+        await selectTicket(page, 'Early Bird Ticket');
+        await expect(page.locator('text=You qualify for the following promo code:')).toBeVisible();
+
+        await selectTicket(page, 'Standard Ticket');
+        await expect(page.locator('text=Following promo code applies to a different ticket. Apply to switch.')).toBeVisible();
+        // The personal "You qualify" copy must be gone — banner stays visible
+        // but accurate about the current pick.
+        await expect(page.locator('text=You qualify for the following promo code:')).toHaveCount(0);
+    });
 });
 
 test.describe('auto-apply flow (auto_apply: true)', () => {

--- a/e2e/promo-code-discovery.spec.js
+++ b/e2e/promo-code-discovery.spec.js
@@ -288,7 +288,7 @@ test.describe('no tickets available', () => {
 });
 
 test.describe('ticket switching with applied code', () => {
-    test('removes discovered code when switching to non-qualifying ticket', async ({ page }) => {
+    test('keeps code applied and surfaces INVALID when switching to non-qualifying ticket', async ({ page }) => {
         const qualifying = ticketType({ id: 188, name: 'Early Bird Ticket' });
         const nonQualifying = ticketType({ id: 999, name: 'Standard Ticket' });
         const code = discoveredCode({ auto_apply: true, allowed_ticket_types: [188] });
@@ -296,15 +296,28 @@ test.describe('ticket switching with applied code', () => {
         await setupRoutes(page, {
             tickets: [qualifying, nonQualifying],
             discovery: [code],
-            validation: { status: 200, body: validationResponse() },
+            // Reject the validate call when targeting the non-qualifying ticket type.
+            validation: (route) => {
+                if (route.request().url().includes('ticket_type_id%3D%3D999')) {
+                    return route.fulfill({
+                        status: 412,
+                        contentType: 'application/json',
+                        body: JSON.stringify(validationError('Promo code EARLYBIRD can not be applied to Ticket Type Standard Ticket.')),
+                    });
+                }
+                return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(validationResponse()) });
+            },
         });
         await page.goto('/');
         await selectTicket(page, 'Early Bird Ticket');
         await expect(page.locator('text=Following promo code was automatically applied:')).toBeVisible();
 
         await selectTicket(page, 'Standard Ticket');
-        await expect(page.locator('text=Do you have a promo code?')).toBeVisible();
-        await expect(page.locator('input[placeholder="Enter your promo code"]')).toHaveValue('');
+        // The code is no longer silently removed on a non-qualifying ticket switch;
+        // it stays applied and is re-validated, surfacing the backend rejection so
+        // the user can choose to Remove or pick another qualifying ticket.
+        await expect(page.locator('input[placeholder="Enter your promo code"]')).toHaveValue('EARLYBIRD');
+        await expect(page.locator('text=Promo code EARLYBIRD can not be applied to Ticket Type Standard Ticket.')).toBeVisible();
     });
 
     test('suggestion appears when switching back to qualifying ticket', async ({ page }) => {

--- a/e2e/promo-code-invalid-clears-warning.spec.js
+++ b/e2e/promo-code-invalid-clears-warning.spec.js
@@ -1,0 +1,57 @@
+const { test, expect } = require('@playwright/test');
+const {
+    ticketType,
+    discoveryResponse,
+    ticketTypesResponse,
+    taxTypesResponse,
+    validationError,
+} = require('./fixtures');
+
+// The unapplied-code warning ("you typed a code but didn't click Apply") must yield
+// to the hook's own validation error once the backend rejects the code. Without the
+// fix, the warning kept its precedence in the merged display slot, masking the
+// more specific "Promo code entered is not valid" message after a failed Apply.
+
+const UNAPPLIED_WARNING = "You entered a promo code but it hasn't been applied";
+const INVALID_MESSAGE = 'Promo code entered is not valid.';
+
+test('INVALID status clears the unapplied-code warning', async ({ page }) => {
+    await page.route('**/promo-codes/all/discover*', route =>
+        route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(discoveryResponse([])) })
+    );
+    await page.route('**/ticket-types/allowed*', route =>
+        route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(ticketTypesResponse([ticketType()])) })
+    );
+    await page.route('**/tax-types*', route =>
+        route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(taxTypesResponse()) })
+    );
+    await page.route('**/promo-codes/*/apply*', route =>
+        route.fulfill({
+            status: 412,
+            contentType: 'application/json',
+            body: JSON.stringify(validationError('The Promo Code "BAD" is not a valid code.')),
+        })
+    );
+
+    await page.goto('/');
+
+    // Select a ticket so the Next button is enabled.
+    await page.locator('[data-testid="ticket-dropdown"]').click();
+    await page.locator('[data-testid="ticket-list"] >> text=Early Bird Ticket').click();
+
+    // Type a code WITHOUT clicking Apply, then hit Next.
+    // This is the trigger for the unapplied-code warning.
+    await page.fill('input[placeholder="Enter your promo code"]', 'BAD');
+    await page.click('button:has-text("Next")');
+
+    // Warning is visible, INVALID message is not.
+    await expect(page.locator(`text=${UNAPPLIED_WARNING}`)).toBeVisible();
+    await expect(page.locator(`text=${INVALID_MESSAGE}`)).not.toBeVisible();
+
+    // Now click Apply. Backend rejects with 412 — the hook surfaces the INVALID message.
+    await page.click('button:has-text("Apply")');
+
+    // The unapplied warning must give way to the more specific rejection reason.
+    await expect(page.locator(`text=${INVALID_MESSAGE}`)).toBeVisible();
+    await expect(page.locator(`text=${UNAPPLIED_WARNING}`)).not.toBeVisible();
+});

--- a/src/components/promocode-input/index.js
+++ b/src/components/promocode-input/index.js
@@ -18,7 +18,7 @@ import styles from "./index.module.scss";
 import { avoidTooltipOverflow } from '../../utils/utils';
 import { PROMO_STATUS } from '../../utils/constants';
 
-const PromoCodeInput = ({ promoStatus, promoCode, suggestedCode, isAutoApplied, onApply, onRemove, onInputChange, showMultipleTicketTexts }) => {
+const PromoCodeInput = ({ promoStatus, promoCode, suggestedCode, isAutoApplied, isCurrentTicketQualifying, onApply, onRemove, onInputChange, showMultipleTicketTexts }) => {
 
     const [userTypedValue, setUserTypedValue] = useState('');
 
@@ -49,11 +49,17 @@ const PromoCodeInput = ({ promoStatus, promoCode, suggestedCode, isAutoApplied, 
             case PROMO_STATUS.INVALID:
                 return undefined;
             case PROMO_STATUS.SUGGESTED:
-                return T.translate('promo_code.suggestion_label');
+                // The suggestion banner stays visible across non-qualifying ticket
+                // picks (so the "Apply will switch you" affordance persists). Swap
+                // the copy so it stays accurate: tell the user the code applies to
+                // a different ticket and that Apply will switch them.
+                return isCurrentTicketQualifying
+                    ? T.translate('promo_code.suggestion_label')
+                    : T.translate('promo_code.suggestion_label_switch');
             default:
                 return undefined;
         }
-    }, [promoStatus, isAutoApplied]);
+    }, [promoStatus, isAutoApplied, isCurrentTicketQualifying]);
 
     const canApply = !isLocked && !!inputValue;
 

--- a/src/components/registration-form/index.js
+++ b/src/components/registration-form/index.js
@@ -268,13 +268,20 @@ const RegistrationFormContent = (
     // of the hook's own validation error (API rejection or status-derived).
     const ticketStepError = unappliedCodeWarning ?? promoState.validationError;
 
-    // Clear the unapplied-code warning once the condition that would have raised it
-    // no longer holds (input cleared, code applied, or a suggestion is showing).
+    // Clear the unapplied-code warning once it's no longer the right message to show.
+    // The hook's own validationError takes precedence: if the user actually clicked
+    // Apply and the backend rejected, surfacing "you didn't apply" would mask the
+    // specific rejection reason. Depending on validationError (rather than on
+    // applyPromoCode's brief Redux promoCode=truthy window) keeps the cleanup
+    // robust against refactors of the apply action's sequencing.
     useEffect(() => {
-        if (!formValues?.promoCode || promoCode || promoState.status === PROMO_STATUS.SUGGESTED) {
+        if (!formValues?.promoCode
+            || promoCode
+            || promoState.status === PROMO_STATUS.SUGGESTED
+            || promoState.validationError) {
             setUnappliedCodeWarning(null);
         }
-    }, [formValues?.promoCode, promoCode, promoState.status])
+    }, [formValues?.promoCode, promoCode, promoState.status, promoState.validationError])
 
     const [ref, { height }] = useMeasure();
 

--- a/src/components/ticket-type/index.js
+++ b/src/components/ticket-type/index.js
@@ -95,10 +95,12 @@ const TicketTypeComponent = ({
             // Once apply settles, prefer the first ticket the discovered code applies
             // to (so per-ticket validation succeeds); fall back to the only ticket
             // when there's a single option.
-            if (promoCode && !promoState.applyingCode && originalTicketTypes.length > 0) {
+            // Scan allowedTicketTypes (date-filtered) so we never auto-select
+            // a ticket the user couldn't have picked themselves from the dropdown.
+            if (promoCode && !promoState.applyingCode && allowedTicketTypes.length > 0) {
                 const isValid = promoState.isCodeValidForTicket;
-                const qualifying = isValid && originalTicketTypes.find(isValid);
-                const toSelect = qualifying || (originalTicketTypes.length === 1 ? originalTicketTypes[0] : null);
+                const qualifying = isValid && allowedTicketTypes.find(isValid);
+                const toSelect = qualifying || (allowedTicketTypes.length === 1 ? allowedTicketTypes[0] : null);
                 if (toSelect) handleTicketChange(toSelect);
             }
             return;
@@ -111,7 +113,7 @@ const TicketTypeComponent = ({
             setTicket(null);
             setQuantity(minQuantity);
         }
-    }, [promoCode, promoState.applyingCode, originalTicketTypes])
+    }, [promoCode, promoState.applyingCode, allowedTicketTypes, originalTicketTypes])
 
     const showTicketSelector = allowedTicketTypes.length > 0;
 

--- a/src/components/ticket-type/index.js
+++ b/src/components/ticket-type/index.js
@@ -89,9 +89,17 @@ const TicketTypeComponent = ({
         // When promo code changes, the API returns updated ticket types with/without discount.
         // Sync the selected ticket with the refreshed data.
         if (!ticket) {
-            // Auto-select if only one ticket type available after promo code applied
-            if (promoCode && originalTicketTypes.length === 1) {
-                handleTicketChange(originalTicketTypes[0]);
+            // Auto-select after a promo code is applied. Defer while applyingCode is
+            // true: the reducer sets promoCode synchronously before the refreshed
+            // ticketTypes land, so acting now would auto-select from a stale list.
+            // Once apply settles, prefer the first ticket the discovered code applies
+            // to (so per-ticket validation succeeds); fall back to the only ticket
+            // when there's a single option.
+            if (promoCode && !promoState.applyingCode && originalTicketTypes.length > 0) {
+                const isValid = promoState.isCodeValidForTicket;
+                const qualifying = isValid && originalTicketTypes.find(isValid);
+                const toSelect = qualifying || (originalTicketTypes.length === 1 ? originalTicketTypes[0] : null);
+                if (toSelect) handleTicketChange(toSelect);
             }
             return;
         }
@@ -103,7 +111,7 @@ const TicketTypeComponent = ({
             setTicket(null);
             setQuantity(minQuantity);
         }
-    }, [promoCode, originalTicketTypes])
+    }, [promoCode, promoState.applyingCode, originalTicketTypes])
 
     const showTicketSelector = allowedTicketTypes.length > 0;
 
@@ -164,7 +172,22 @@ const TicketTypeComponent = ({
     const decrementQuantity = () => setQuantity(quantity - 1);
 
     const handleApplyPromoCode = async (code) => {
-        await promoActions.onApply(code, ticket, quantity);
+        // If the user applies the suggested/discovered code while a
+        // non-qualifying ticket is selected, deselect first. The qualifying
+        // ticket may not yet be in originalTicketTypes (it's revealed by the
+        // code-filtered refetch inside applyPromoCode). After apply resolves,
+        // the post-apply effect picks the qualifying ticket from the
+        // refreshed list. Manual non-discovered codes still validate against
+        // the current ticket — backend decides.
+        const isDiscovered = code === promoState.suggestedCode;
+        const isValid = promoState.isCodeValidForTicket;
+        let targetTicket = ticket;
+        if (isDiscovered && isValid && ticket && !isValid(ticket)) {
+            setTicket(null);
+            setQuantity(minQuantity);
+            targetTicket = null;
+        }
+        await promoActions.onApply(code, targetTicket, quantity);
     }
 
     return (

--- a/src/components/ticket-type/index.js
+++ b/src/components/ticket-type/index.js
@@ -319,6 +319,7 @@ const TicketTypeComponent = ({
                                         promoCode={promoCode}
                                         suggestedCode={promoState.suggestedCode}
                                         isAutoApplied={promoState.isAutoApplied}
+                                        isCurrentTicketQualifying={promoState.isCodeValidForTicket(ticket)}
                                         onInputChange={promoActions.onInputChange}
                                         onApply={handleApplyPromoCode}
                                         onRemove={promoActions.onRemove}

--- a/src/hooks/__tests__/usePromoCode.test.js
+++ b/src/hooks/__tests__/usePromoCode.test.js
@@ -288,12 +288,14 @@ describe('onTicketSelected', () => {
         expect(result.current.state.status).toBe(PROMO_STATUS.SUGGESTED);
     });
 
-    it('removes discovered code when switching to non-qualifying ticket', async () => {
+    it('re-validates discovered code when switching to non-qualifying ticket', async () => {
+        const validatePromoCode = jest.fn(() => Promise.resolve());
         const removePromoCode = jest.fn();
         const props = createDefaultProps({
             discoveredPromoCodes: mockDiscoveredCodes,
             promoCode: 'AUTO1',
             promoCodeVerified: true,
+            validatePromoCode,
             removePromoCode,
         });
         const { result } = renderHook(() => usePromoCode(props));
@@ -301,10 +303,12 @@ describe('onTicketSelected', () => {
         await act(async () => {
             await result.current.actions.onTicketSelected(mockTicketNonQualifying);
         });
-        expect(removePromoCode).toHaveBeenCalled();
+        // Per c60b30e: surface backend rejection instead of silently removing.
+        expect(validatePromoCode).toHaveBeenCalled();
+        expect(removePromoCode).not.toHaveBeenCalled();
     });
 
-    it('removes discovered code when ticket is not in allowed list', async () => {
+    it('re-validates discovered code when ticket is not in allowed list', async () => {
         const validatePromoCode = jest.fn(() => Promise.resolve());
         const removePromoCode = jest.fn();
         const ticket2 = { id: 2, sub_type: 'Regular' };
@@ -320,9 +324,10 @@ describe('onTicketSelected', () => {
         await act(async () => {
             await result.current.actions.onTicketSelected(ticket2);
         });
-        // AUTO1 allowed_ticket_types is [{ id: 1 }], ticket2 has id: 2
-        expect(removePromoCode).toHaveBeenCalled();
-        expect(validatePromoCode).not.toHaveBeenCalled();
+        // AUTO1 allowed_ticket_types is [{ id: 1 }], ticket2 has id: 2.
+        // Backend decides — hook re-validates rather than removing client-side.
+        expect(validatePromoCode).toHaveBeenCalled();
+        expect(removePromoCode).not.toHaveBeenCalled();
     });
 
     it('re-validates manual code when switching tickets', async () => {
@@ -906,18 +911,20 @@ describe('early auto-apply', () => {
         expect(applyPromoCode).toHaveBeenCalledWith('AUTO1');
     });
 
-    it('does not fire when tickets are already available', async () => {
+    it('fires even when tickets are already available (per SDS)', async () => {
+        // Per a8590e2: the hasTickets gate was removed; single auto_apply codes
+        // fire as soon as ticket data has loaded regardless of public availability.
         const applyPromoCode = jest.fn(() => Promise.resolve());
-        renderHook(() =>
-            usePromoCode(createDefaultProps({
-                discoveredPromoCodes: singleAutoApplyCode,
-                applyPromoCode,
-                ticketDataLoaded: true,
-                hasTickets: true,
-            }))
-        );
+        const baseProps = createDefaultProps({
+            discoveredPromoCodes: singleAutoApplyCode,
+            applyPromoCode,
+            ticketDataLoaded: true,
+            hasTickets: true,
+        });
+        const { rerender } = renderHook((props) => usePromoCode(props), { initialProps: baseProps });
         await act(async () => { await flushPromises(); });
-        expect(applyPromoCode).not.toHaveBeenCalled();
+        rerender({ ...baseProps, promoCode: 'AUTO1' });
+        expect(applyPromoCode).toHaveBeenCalledWith('AUTO1');
     });
 
     it('does not fire when ticket data is still loading', async () => {

--- a/src/hooks/usePromoCode.js
+++ b/src/hooks/usePromoCode.js
@@ -135,10 +135,12 @@ const usePromoCode = ({
     //
     // Note on concurrency: the two call sites (early-auto-apply effect and
     // onTicketSelected's auto-apply branch) operate on disjoint states by design
-    // (the effect requires `!hasTickets`, the branch requires a selected ticket),
-    // so a true concurrent invocation is unreachable in practice. If a future
-    // change makes that overlap possible, gate this body with a ref-tracked
-    // in-flight flag rather than `applyingCode` (which is captured stale here).
+    // (the effect requires `!isApplied`, the branch fires only on a user-driven
+    // ticket selection — by which point isApplied is already true if early
+    // auto-apply ran), so a true concurrent invocation is unreachable in
+    // practice. If a future change makes that overlap possible, gate this body
+    // with a ref-tracked in-flight flag rather than `applyingCode` (which is
+    // captured stale here).
     const tryAutoApply = useCallback(async (ticket) => {
         setIsAutoApplied(true);
         setApplyingCode(true);
@@ -193,19 +195,20 @@ const usePromoCode = ({
     }, [discoveredPromoCode, isApplied, isDiscoveredCode, userRemovedAutoApply, discoveredPromoCodes,
         isCodeValidForTicket, onRevalidate, tryAutoApply]);
 
-    // Early auto-apply: when no tickets are available and a single auto_apply code
-    // was discovered, apply it so the API returns WithPromoCode ticket types.
-    // On failure, mark as removed to prevent re-fire loops.
+    // Early auto-apply on load (per SDS: silently apply a discovered single
+    // auto_apply code when no code is currently applied). Wait on
+    // ticketDataLoaded only to avoid racing the initial fetch. On failure,
+    // mark as removed to prevent re-fire loops.
     useEffect(() => {
         if (userRemovedAutoApply || isApplied) return;
-        if (!ticketDataLoaded || hasTickets) return;
+        if (!ticketDataLoaded) return;
         if (!discoveredPromoCode?.auto_apply) return;
         if (discoveredPromoCodes.length !== 1) return;
 
         tryAutoApply(null).then(success => {
             if (!success) setUserRemovedAutoApply(true);
         });
-    }, [userRemovedAutoApply, ticketDataLoaded, hasTickets, discoveredPromoCode, discoveredPromoCodes, isApplied, tryAutoApply]);
+    }, [userRemovedAutoApply, ticketDataLoaded, discoveredPromoCode, discoveredPromoCodes, isApplied, tryAutoApply]);
 
     const onApply = useCallback(async (code, ticket, quantity) => {
         setManualError(null);

--- a/src/hooks/usePromoCode.js
+++ b/src/hooks/usePromoCode.js
@@ -175,15 +175,14 @@ const usePromoCode = ({
 
         if (!discoveredPromoCode) return;
 
-        // Discovered code is currently applied
+        // Discovered code is currently applied — re-validate against the new
+        // ticket. The backend rejects if the code doesn't apply, surfacing
+        // INVALID to the user (they can then choose to Remove or pick another
+        // ticket). Previously we silently removed the code on a non-qualifying
+        // pick, which hid the rejection.
         if (isDiscoveredCode) {
-            if (!qualifies) {
-                setIsAutoApplied(false);
-                removePromoCode();
-            } else {
-                const valid = await onRevalidate(ticket, 1);
-                if (!valid) setIsAutoApplied(false);
-            }
+            const valid = await onRevalidate(ticket, 1);
+            if (!valid) setIsAutoApplied(false);
             return;
         }
 
@@ -192,7 +191,7 @@ const usePromoCode = ({
             await tryAutoApply(ticket);
         }
     }, [discoveredPromoCode, isApplied, isDiscoveredCode, userRemovedAutoApply, discoveredPromoCodes,
-        isCodeValidForTicket, removePromoCode, onRevalidate, tryAutoApply]);
+        isCodeValidForTicket, onRevalidate, tryAutoApply]);
 
     // Early auto-apply: when no tickets are available and a single auto_apply code
     // was discovered, apply it so the API returns WithPromoCode ticket types.

--- a/src/hooks/usePromoCode.js
+++ b/src/hooks/usePromoCode.js
@@ -165,7 +165,13 @@ const usePromoCode = ({
 
     const onTicketSelected = useCallback(async (ticket) => {
         const qualifies = discoveredPromoCode && isCodeValidForTicket(ticket);
-        setSuggestionActive(qualifies);
+        // Only turn the suggestion on when the current ticket qualifies; don't
+        // turn it off otherwise. With auto-switch-on-Apply, the suggestion is
+        // still useful when the user has a non-qualifying ticket selected
+        // (Apply will switch them to the qualifying one). The status logic
+        // hides the banner whenever a code is applied, so leaving this true
+        // doesn't surface a stale suggestion.
+        if (qualifies) setSuggestionActive(true);
         setSuggestionDismissed(false);
         setManualError(null);
 
@@ -251,6 +257,11 @@ const usePromoCode = ({
             status,
             isReady,
             validationError,
+            // True while applyPromoCode is in flight (covers the window where
+            // promoCode is set but the refreshed ticketTypes haven't landed
+            // yet). Callers should defer ticket-list-driven side effects
+            // until this clears to avoid acting on a stale list.
+            applyingCode,
 
             // Applied code origin
             isDiscoveredCode,
@@ -258,6 +269,10 @@ const usePromoCode = ({
 
             // Discovery / suggestion
             suggestedCode,
+            // Predicate the caller can use to find a ticket the discovered
+            // promo applies to (auto-selection after auto-apply, ticket
+            // switching on Apply).
+            isCodeValidForTicket,
 
             // Quantity caps from the active discovered code
             maxQuantityFromPromo,

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -23,6 +23,7 @@
     "applied_label": "Applied promo code:",
     "applying_label": "Applying promo code...",
     "suggestion_label": "You qualify for the following promo code:",
+    "suggestion_label_switch": "Following promo code applies to a different ticket. Apply to switch.",
     "per_account_limit_one": "Promo code limits {limit} ticket per account.",
     "per_account_limit_other": "Promo code limits {limit} tickets per account.",
     "non_transferable": "This ticket will be automatically assigned to you and cannot be reassigned.",


### PR DESCRIPTION
ref: https://app.clickup.com/t/86ba9qt03

## Per-commit summary

**1. `c60b30e` — Re-validate the discovered code when the user switches tickets**
- Before: switching to a ticket the code doesn't apply to *silently removed the code*. The user never saw why.
- After: always re-validate against the new ticket. The backend rejection reaches the user as `INVALID`, so they can choose Remove or pick a different ticket.

**2. `a8590e2` — Fire early auto-apply per the SDS rule**
- Before: auto-apply on load required the ticket list to be empty (`!hasTickets`). If public tickets were already visible, auto-apply never fired.
- After: per SDS, auto-apply fires whenever a single `auto_apply` code is discovered and none is applied. The `hasTickets` gate is gone.

**3. `a718823` — Auto-switch to the qualifying ticket on Apply**
- Before: with the suggestion banner visible, clicking Apply while a non-qualifying ticket was selected returned `INVALID` against that ticket. Misleading after the UI just said "you qualify".
- After: three coordinated changes:
  - On Apply of the suggested code, if the current ticket doesn't qualify → deselect it first.
  - Wait for the code-filtered ticket-list refresh, then auto-pick the first qualifying ticket. Falls back to the only-ticket case when nothing qualifies.
  - Keep the suggestion banner visible across non-qualifying ticket picks, so the "click Apply" prompt doesn't disappear.
- Exposes `applyingCode` and `isCodeValidForTicket` from `usePromoCode` so the ticket-type caller can drive both the gate and the qualifying pick.
- Manual (non-discovered) codes are unaffected.

**4. `8b9b814` — Auto-select only from tickets the user can actually buy** *(+ new e2e spec)*
- Before: the post-apply auto-select scanned the unfiltered Redux ticket list. A code could pick a ticket *outside its sales window*. The dropdown only lists in-window tickets, so the user couldn't change the selection.
- After: scans the date-filtered list (`allowedTicketTypes`) — same list the dropdown uses.
- New regression spec covers both the expired-vs-active discriminator and the all-out-of-window case.

**5. `98a7ba5` — Make the "you didn't click Apply" warning yield to a real validation error** *(+ new e2e spec)*
- Background: when the user types a code but skips Apply, the form shows "you typed a code but didn't apply it". Today that warning happens to clear correctly only because `applyPromoCode` briefly sets Redux `promoCode` to truthy before clearing it on failure — a race window inside the action.
- Before: the cleanup depends on that race. A reasonable refactor of `applyPromoCode` (e.g. "only set state on success") would silently leave the stale warning masking the actual "invalid code" message.
- After: cleanup keys off the hook's own `validationError` directly. Same behavior today, robust to future refactors of the apply action.
- New regression spec guards the precedence between the two messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-selects the first qualifying ticket from the allowed/date-filtered set when a promo code is applied.
  * Discovered promo codes can auto-apply as soon as ticket data is loaded.

* **Bug Fixes**
  * Unapplied-code warnings clear when validation errors occur; backend validation errors are shown without removing promo input.
  * When only expired tickets qualify, no ticket is auto-selected and the placeholder/no-ticket UI displays.

* **Tests**
  * Added/expanded end-to-end and hook tests covering discovery, auto-apply, switching, and invalid-code flows.

* **Localization**
  * New promo copy for suggesting a code that applies to a different ticket.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->