### PR TITLE
Fix the discover integration test against the merged promo hook

### DIFF
--- a/src/__tests__/discoverPromoCodes.integration.test.js
+++ b/src/__tests__/discoverPromoCodes.integration.test.js
@@ -21,7 +21,7 @@
  *          would before dispatching the success action.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react-hooks';
 import { createStore, combineReducers, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 
@@ -171,15 +171,20 @@ describe('discoverPromoCodes — request → reducer → hook, end to end', () =
         const { result } = renderHook(() => usePromoCode({
             discoveredPromoCodes,
             promoCode: 'PRESALE',
-            promoCodeVerified: true,
-            promoCodeValidating: false,
             applyPromoCode: jest.fn(() => Promise.resolve()),
             removePromoCode: jest.fn(),
-            validatePromoCode: jest.fn(() => Promise.resolve()),
+            validatePromoCode: jest.fn(() => Promise.resolve({ response: {} })),
             setFormPromoCode: jest.fn(),
             ticketDataLoaded: true,
             hasTickets: true,
         }));
+
+        // Whether the code was accepted is the hook's own state now, not a
+        // prop: earn it the way the app does, with one successful validation
+        // against a qualifying ticket.
+        await act(async () => {
+            await result.current.actions.onRevalidate({ id: 202, sub_type: 'Regular' }, 1);
+        });
 
         expect(result.current.state.suggestedCode).toBe('PRESALE');
         expect(result.current.state.perAccountLimit).toBe(24);


### PR DESCRIPTION
ref: https://app.clickup.com/t/86bb9xgex

Fixes the CI break on main after #150 and #151 merged.

Each PR was green alone. #150's integration test fed the promo hook promoCodeVerified as a prop; #151 moved that state inside the hook, where it is earned by validating. Merged together, the prop is ignored, the discovered code never counts as active, and the test fails.

The test now runs one successful validation against a qualifying ticket, the way the app reaches that state. Test-only change; 133 unit and 33 e2e green on merged main plus this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration coverage for the current promo-code validation flow.
  * Added verification for revalidation with an eligible ticket and successful valid-code handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->