### PR TITLE
Correct stale promo validation comments and drop a dead action

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -53,7 +53,6 @@ export const SET_CURRENT_PROMO_CODE = 'SET_CURRENT_PROMO_CODE';
 export const CLEAR_CURRENT_PROMO_CODE = 'CLEAR_CURRENT_PROMO_CODE';
 export const VALIDATE_PROMO_CODE = 'VALIDATE_PROMO_CODE';
 export const VALIDATE_PROMO_CODE_SUCCESS = 'VALIDATE_PROMO_CODE_SUCCESS';
-export const VALIDATE_PROMO_CODE_ERROR = 'VALIDATE_PROMO_CODE_ERROR';
 export const DISCOVER_PROMO_CODES = 'DISCOVER_PROMO_CODES';
 export const DISCOVER_PROMO_CODES_SUCCESS = 'DISCOVER_PROMO_CODES_SUCCESS';
 
@@ -230,9 +229,11 @@ export const removePromoCode = () => (dispatch, getState) => {
 }
 
 /**
- * Validates promo code for a specific ticket selection.
- * Stores allows_to_reassign in Redux state.
- * Returns response or throws error - caller handles UI concerns.
+ * Validates the applied promo code for a ticket selection. Resolves with the
+ * API response (usePromoCode reads allows_to_reassign from it) or rejects;
+ * the caller owns all UI concerns. The two actions dispatched below reach no
+ * reducer; they are devtools breadcrumbs, and getRequest requires a receive
+ * action to deliver the response.
  */
 export const validatePromoCode = (ticketData) => async (dispatch, getState, { apiBaseUrl, getAccessToken }) => {
     const { registrationLiteState: { settings: { summitId }, promoCode: currentPromoCode } } = getState();

--- a/src/hooks/usePromoCode.js
+++ b/src/hooks/usePromoCode.js
@@ -63,13 +63,14 @@ const usePromoCode = ({
     const isDiscoveredCode = isApplied && discoveredPromoCode?.code === promoCode;
 
     // --- Canonical signals ---
-    // The raw Redux signals can overlap (e.g. a stale promoCodeVerified=false
-    // persists while a re-validation is in flight), so precedence is encoded
-    // here, once, rather than in each consumer.
+    // The raw signals can overlap (a rejection stays recorded while a
+    // re-validation runs), so precedence is encoded here, once, rather than
+    // in each consumer.
 
     // Something genuinely in flight: applying the code, validating it against
-    // a ticket, or waiting on the code-filtered ticket list with no settled
-    // answer to show in the meantime.
+    // a ticket, or -- for an anonymous user who applies a code while the
+    // initial ticket list is still loading -- waiting for that list, with no
+    // settled answer to show in the meantime.
     const isBusy = applyingCode || validatingCode
         || (isApplied && promoCodeVerified == null && !ticketDataLoaded);
 


### PR DESCRIPTION
ref: https://app.clickup.com/t/86bbdpxyn

Comment cleanup after the promo validation rework. Two comments still described the old Redux flow, and VALIDATE_PROMO_CODE_ERROR was exported but referenced nowhere. No behavior change. The isBusy ticket-data clause was checked as a removal candidate and stays: anonymous sessions render the form while the initial ticket list loads, so it is reachable.