### PR TITLE
Treat quantity 0 as unlimited in ticket and promo caps

### DIFF
--- a/src/components/ticket-type/__tests__/per-order-notice.test.js
+++ b/src/components/ticket-type/__tests__/per-order-notice.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import T from 'i18n-react';
+import TicketTypeComponent from '..';
+
+T.setTexts(require('../../../i18n/en.json'));
+
+const unlimitedStockTicket = {
+    id: 1,
+    name: 'General Admission',
+    currency: 'USD',
+    currency_symbol: '$',
+    quantity_2_sell: 0,          // API semantics: 0 = unlimited stock
+    quantity_sold: 10,
+    max_quantity_per_order: 4,   // real, binding per-order cap
+};
+
+it('shows the per-order limit notice when stock is unlimited (quantity_2_sell 0)', () => {
+    const { getByText } = render(
+        <TicketTypeComponent
+            isActive
+            allowedTicketTypes={[unlimitedStockTicket]}
+            originalTicketTypes={[unlimitedStockTicket]}
+            taxTypes={[]}
+            changeForm={jest.fn()}
+            trackViewItem={jest.fn()}
+            allowPromoCodes={false}
+            reservation={{ tickets: [{ ticket_type_id: 1 }] }}
+        />
+    );
+
+    // The stepper caps at 4 (getTicketMaxQuantity treats quantity_2_sell 0 as
+    // unlimited stock), so the notice explaining that cap must be shown.
+    expect(getByText('This ticket type is limited to 4 per order.')).toBeInTheDocument();
+});

--- a/src/components/ticket-type/index.js
+++ b/src/components/ticket-type/index.js
@@ -131,7 +131,7 @@ const TicketTypeComponent = ({
     const ticketPerOrderLimit = useMemo(() => {
         if (!ticket) return null;
         const cap = ticket.max_quantity_per_order;
-        const inventory = (ticket.quantity_2_sell ?? Number.MAX_SAFE_INTEGER) - (ticket.quantity_sold ?? 0);
+        const inventory = (ticket.quantity_2_sell || Number.MAX_SAFE_INTEGER) - (ticket.quantity_sold ?? 0);
         return cap != null && cap > 0 && cap < inventory ? cap : null;
     }, [ticket]);
 

--- a/src/helpers/__tests__/getTicketMaxQuantity.test.js
+++ b/src/helpers/__tests__/getTicketMaxQuantity.test.js
@@ -1,0 +1,49 @@
+import { getTicketMaxQuantity } from '../getTicketMaxQuantity';
+import { TICKET_TYPE_SUBTYPE_PREPAID } from '../../utils/constants';
+
+describe('getTicketMaxQuantity', () => {
+    it('returns 0 when no ticket is given', () => {
+        expect(getTicketMaxQuantity(null)).toBe(0);
+    });
+
+    it('caps at the remaining stock when there is a real per-order limit', () => {
+        // 100 to sell, 90 sold, up to 5 per order -> per-order limit wins
+        const ticket = { quantity_2_sell: 100, quantity_sold: 90, max_quantity_per_order: 5 };
+        expect(getTicketMaxQuantity(ticket)).toBe(5);
+    });
+
+    it('caps at remaining stock when stock is the tighter limit', () => {
+        // 100 to sell, 97 sold, up to 5 per order -> only 3 left
+        const ticket = { quantity_2_sell: 100, quantity_sold: 97, max_quantity_per_order: 5 };
+        expect(getTicketMaxQuantity(ticket)).toBe(3);
+    });
+
+    it('treats max_quantity_per_order of 0 as unlimited (the sold-out bug)', () => {
+        // ticket 212 from prod: 2900 to sell, 2832 sold, per-order limit 0 (API = no limit)
+        // 68 tickets remain, so it must NOT read as sold out
+        const ticket = { quantity_2_sell: 2900, quantity_sold: 2832, max_quantity_per_order: 0 };
+        expect(getTicketMaxQuantity(ticket)).toBe(68);
+    });
+
+    it('treats quantity_2_sell of 0 as unlimited stock', () => {
+        // 0 to sell = no cap on stock; per-order limit of 4 is the only bound
+        const ticket = { quantity_2_sell: 0, quantity_sold: 10, max_quantity_per_order: 4 };
+        expect(getTicketMaxQuantity(ticket)).toBe(4);
+    });
+
+    it('still returns <= 0 for a genuinely sold-out ticket', () => {
+        // real cap reached: 100 to sell, 100 sold
+        const ticket = { quantity_2_sell: 100, quantity_sold: 100, max_quantity_per_order: 5 };
+        expect(getTicketMaxQuantity(ticket)).toBeLessThan(1);
+    });
+
+    it('applies the remaining-per-account cap when it is the tightest', () => {
+        const ticket = { quantity_2_sell: 100, quantity_sold: 10, max_quantity_per_order: 10 };
+        expect(getTicketMaxQuantity(ticket, 2)).toBe(2);
+    });
+
+    it('always returns 1 for prepaid ticket types', () => {
+        const ticket = { sub_type: TICKET_TYPE_SUBTYPE_PREPAID, quantity_2_sell: 0, quantity_sold: 0, max_quantity_per_order: 0 };
+        expect(getTicketMaxQuantity(ticket)).toBe(1);
+    });
+});

--- a/src/helpers/__tests__/getTicketMaxQuantity.test.js
+++ b/src/helpers/__tests__/getTicketMaxQuantity.test.js
@@ -31,6 +31,11 @@ describe('getTicketMaxQuantity', () => {
         expect(getTicketMaxQuantity(ticket)).toBe(4);
     });
 
+    it('defaults quantity_sold to 0 when the API omits it', () => {
+        const ticket = { quantity_2_sell: 100, max_quantity_per_order: 5 };
+        expect(getTicketMaxQuantity(ticket)).toBe(5);
+    });
+
     it('still returns <= 0 for a genuinely sold-out ticket', () => {
         // real cap reached: 100 to sell, 100 sold
         const ticket = { quantity_2_sell: 100, quantity_sold: 100, max_quantity_per_order: 5 };

--- a/src/helpers/getTicketMaxQuantity.js
+++ b/src/helpers/getTicketMaxQuantity.js
@@ -3,7 +3,10 @@ import { isPrePaidTicketType } from '../utils/utils';
 export const getTicketMaxQuantity = (ticket, remainingQuantityPerAccount) => {
     if(!ticket) return 0;
     if(isPrePaidTicketType(ticket)) return 1;
-    let max = Math.min((ticket.quantity_2_sell ?? Number.MAX_SAFE_INTEGER) - ticket.quantity_sold, (ticket.max_quantity_per_order ?? Number.MAX_SAFE_INTEGER));
+    // The API treats 0 as "no limit" for both fields; only a positive value is a real cap.
+    const quantityToSell = ticket.quantity_2_sell || Number.MAX_SAFE_INTEGER;
+    const maxPerOrder = ticket.max_quantity_per_order || Number.MAX_SAFE_INTEGER;
+    let max = Math.min(quantityToSell - (ticket.quantity_sold ?? 0), maxPerOrder);
     if (remainingQuantityPerAccount != null) {
         max = Math.min(max, remainingQuantityPerAccount);
     }

--- a/src/hooks/__tests__/usePromoCode.test.js
+++ b/src/hooks/__tests__/usePromoCode.test.js
@@ -1180,17 +1180,32 @@ describe('maxQuantityFromPromo', () => {
         expect(result.current.state.maxQuantityFromPromo).toBe(3);
     });
 
-    it('caps at 0 when quantity_available is 0 (sold out)', async () => {
+    it('treats quantity_available of 0 as unlimited, falling back to the per-account cap', async () => {
+        // The API treats quantity_available 0 as "no limit" (hasQuantityAvailable),
+        // so it must not zero the stepper; the per-account remaining is the only cap.
         const codes = [{
-            code: 'SOLDOUT',
+            code: 'UNLIMITEDUSES',
             auto_apply: true,
             allowed_ticket_types: [],
             quantity_per_account: 5,
             remaining_quantity_per_account: 3,
             quantity_available: 0,
         }];
-        const { result } = await renderVerified({ discoveredPromoCodes: codes, promoCode: 'SOLDOUT' });
-        expect(result.current.state.maxQuantityFromPromo).toBe(0);
+        const { result } = await renderVerified({ discoveredPromoCodes: codes, promoCode: 'UNLIMITEDUSES' });
+        expect(result.current.state.maxQuantityFromPromo).toBe(3);
+    });
+
+    it('null when quantity_available is 0 and there is no per-account cap', async () => {
+        const codes = [{
+            code: 'FULLYUNLIMITED',
+            auto_apply: true,
+            allowed_ticket_types: [],
+            quantity_per_account: 0,
+            remaining_quantity_per_account: null,
+            quantity_available: 0,
+        }];
+        const { result } = await renderVerified({ discoveredPromoCodes: codes, promoCode: 'FULLYUNLIMITED' });
+        expect(result.current.state.maxQuantityFromPromo).toBeNull();
     });
 
     it('uses only quantity_available when remaining_quantity_per_account is null', async () => {

--- a/src/hooks/usePromoCode.js
+++ b/src/hooks/usePromoCode.js
@@ -119,14 +119,16 @@ const usePromoCode = ({
         ? activeDiscoveredCode.remaining_quantity_per_account : null;
 
     // Tightest promo-code-level quantity cap for the stepper (discovered codes only).
-    // Both cap sources use `!= null` so a value of 0 (sold-out / no remaining) caps the
-    // stepper at 0 instead of being silently ignored.
+    // remaining_quantity_per_account is a real per-account count: null means no limit,
+    // and the API drops a code once the account exhausts it, so it is never 0 here.
+    // quantity_available is a total-use cap where 0 means "no limit" (matches the API's
+    // hasQuantityAvailable), so only a positive value is a real cap on the stepper.
     const maxQuantityFromPromo = useMemo(() => {
         if (!activeDiscoveredCode) return null;
         const caps = [];
         if (activeDiscoveredCode.remaining_quantity_per_account != null)
             caps.push(activeDiscoveredCode.remaining_quantity_per_account);
-        if (activeDiscoveredCode.quantity_available != null)
+        if (activeDiscoveredCode.quantity_available)
             caps.push(activeDiscoveredCode.quantity_available);
         return caps.length > 0 ? Math.min(...caps) : null;
     }, [activeDiscoveredCode]);


### PR DESCRIPTION
ref: https://app.clickup.com/t/86bbebyex

The Registration Lite widget marked a ticket type as Sold Out when its Max Quantity Per Order was 0. The API treats 0 as "no limit", but the widget took it literally as "max 0 per order".

Two layers had the same bug:

- getTicketMaxQuantity: quantity_2_sell and max_quantity_per_order of 0 now mean unlimited. Also guards quantity_sold when absent.
- usePromoCode maxQuantityFromPromo: a promo code quantity_available of 0 now means unlimited (matches the API's hasQuantityAvailable), instead of capping the stepper at 0. remaining_quantity_per_account keeps its meaning; the API never returns 0 for it.

The Complimentary Sponsor ticket in the reported case (2900 to sell, 2832 sold, 68 left, Max Quantity Per Order 0) now shows availability.

Immediate workaround with no deploy: set the ticket type's Max Quantity Per Order to 1 in show admin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected ticket quantity handling so a limit of zero is treated as unlimited rather than sold out.
  - Improved remaining-inventory calculations when sold quantities are unavailable.
  - Updated promotional quantity limits to honor per-account caps while treating zero available quantity as unlimited.
  - Preserved special ticket rules, including prepaid tickets and sold-out inventory behavior.

- **Tests**
  - Added comprehensive coverage for ticket quantity limits, inventory, account restrictions, unlimited quantities, and promotional limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->